### PR TITLE
Fixed problem with umlauts (and other accented characters) in hashtags

### DIFF
--- a/inc/utils.php
+++ b/inc/utils.php
@@ -283,12 +283,8 @@ function ozh_ta_trim_long_string( $text, $len = 30 ) {
 function ozh_ta_get_tag_link( $tag ) {
 	global $wp_rewrite;
 	$link = $wp_rewrite->get_tag_permastruct();
-    
-	error_log("Original tag $tag");
-	
+    	
 	$tag = sanitize_title_with_dashes( remove_accents( $tag ) );
-error_log("sanitized tag $tag");
-	
 	
 	if( empty( $link ) ) {
 		// site.com/?tag=bleh

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -284,7 +284,7 @@ function ozh_ta_get_tag_link( $tag ) {
 	global $wp_rewrite;
 	$link = $wp_rewrite->get_tag_permastruct();
     
-	$tag = remove_accents( sanitize_title_with_dashes( $tag ) );
+	$tag = sanitize_title_with_dashes( remove_accents( $tag ) );
 
 	if( empty( $link ) ) {
 		// site.com/?tag=bleh

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -284,8 +284,12 @@ function ozh_ta_get_tag_link( $tag ) {
 	global $wp_rewrite;
 	$link = $wp_rewrite->get_tag_permastruct();
     
+	error_log("Original tag $tag");
+	
 	$tag = sanitize_title_with_dashes( remove_accents( $tag ) );
-
+error_log("sanitized tag $tag");
+	
+	
 	if( empty( $link ) ) {
 		// site.com/?tag=bleh
 		$link = trailingslashit( home_url() ) . '?tag=' . $tag;

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -284,7 +284,7 @@ function ozh_ta_get_tag_link( $tag ) {
 	global $wp_rewrite;
 	$link = $wp_rewrite->get_tag_permastruct();
     
-	$tag = sanitize_title_with_dashes( $tag );
+	$tag = remove_accents( sanitize_title_with_dashes( $tag ) );
 
 	if( empty( $link ) ) {
 		// site.com/?tag=bleh

--- a/ozh-ta.php
+++ b/ozh-ta.php
@@ -3,7 +3,7 @@
 Plugin Name: Ozh' Tweet Archiver
 Plugin URI: http://planetozh.com/blog/my-projects/ozh-tweet-archiver-backup-twitter-with-wordpress/
 Description: Archive your tweets and import them as posts
-Version: 2.0.2a
+Version: 2.0.2b
 Author: Ozh
 Author URI: http://ozh.org/
 */

--- a/ozh-ta.php
+++ b/ozh-ta.php
@@ -3,7 +3,7 @@
 Plugin Name: Ozh' Tweet Archiver
 Plugin URI: http://planetozh.com/blog/my-projects/ozh-tweet-archiver-backup-twitter-with-wordpress/
 Description: Archive your tweets and import them as posts
-Version: 2.0.2
+Version: 2.0.2a
 Author: Ozh
 Author URI: http://ozh.org/
 */


### PR DESCRIPTION
This fixes the wrong linking when hashtags include accented characters. (#10)