### PR TITLE
Display multiple images if present.

### DIFF
--- a/inc/import.php
+++ b/inc/import.php
@@ -193,7 +193,7 @@ function ozh_ta_linkify_tweet( $tweet ) {
     }
     
 	// embed images if applicable. This operation shall be the last one
-    if( isset( $tweet->entities->media ) && $medias = $tweet->entities->media ) {
+    if( isset( $tweet->extended_entities->media) && $medias = $tweet->extended_entities->media ) {
         foreach( $medias as $media ) {
             $media_url    = $media->media_url_https;
             $display_url  = $media->display_url;


### PR DESCRIPTION
Use extended_media instead of media (thanks
http://www.leancrew.com/all-this/2014/06/tweets-with-multiple-photos/). This means we can see multiple photos attached at once.

This resolves #23 .